### PR TITLE
Fix hidden initialization

### DIFF
--- a/PyTorch/manhattan_lstm.py
+++ b/PyTorch/manhattan_lstm.py
@@ -70,7 +70,10 @@ class Manhattan_LSTM(nn.Module):
     def init_hidden(self, batch_size):
         # Hidden dimensionality : 2 (h_0, c_0) x Num. Layers * Num. Directions x Batch Size x Hidden Size
         # result = torch.zeros(2, 1, batch_size, self.hidden_size)
-        result = (torch.zeros(1, batch_size, self.hidden_size), torch.zeros(1, batch_size, self.hidden_size))
+        if self.use_cuda:
+            result = (torch.zeros(1, batch_size, self.hidden_size).cuda(),
+                      torch.zeros(1, batch_size, self.hidden_size).cuda())
+        else:
+            result = (torch.zeros(1, batch_size, self.hidden_size), torch.zeros(1, batch_size, self.hidden_size))
 
-        if self.use_cuda: return result.cuda()
-        else: return result
+        return result

--- a/PyTorch/manhattan_lstm.py
+++ b/PyTorch/manhattan_lstm.py
@@ -69,7 +69,8 @@ class Manhattan_LSTM(nn.Module):
 
     def init_hidden(self, batch_size):
         # Hidden dimensionality : 2 (h_0, c_0) x Num. Layers * Num. Directions x Batch Size x Hidden Size
-        result = torch.zeros(2, 1, batch_size, self.hidden_size)
+        # result = torch.zeros(2, 1, batch_size, self.hidden_size)
+        result = (torch.zeros(1, batch_size, self.hidden_size), torch.zeros(1, batch_size, self.hidden_size))
 
         if self.use_cuda: return result.cuda()
         else: return result

--- a/PyTorch/train_network.py
+++ b/PyTorch/train_network.py
@@ -29,7 +29,7 @@ class Train_Network(object):
         loss = 0.0
 
         hidden = self.manhattan_lstm.init_hidden(batch_size)
-        output_scores = self.manhattan_lstm([sequences_1, sequences_2], hidden).view(-1)
+        output_scores = self.manhattan_lstm((sequences_1, sequences_2), hidden).view(-1)
 
         loss += criterion(output_scores, similarity_scores)
 

--- a/PyTorch/train_network.py
+++ b/PyTorch/train_network.py
@@ -29,7 +29,7 @@ class Train_Network(object):
         loss = 0.0
 
         hidden = self.manhattan_lstm.init_hidden(batch_size)
-        output_scores = self.manhattan_lstm((sequences_1, sequences_2), hidden).view(-1)
+        output_scores = self.manhattan_lstm([sequences_1, sequences_2], hidden).view(-1)
 
         loss += criterion(output_scores, similarity_scores)
 


### PR DESCRIPTION
The PyTorch/main.py was throwing the following error:
Traceback (most recent call last):
  File "main.py", line 63, in <module>
    run_iterations.train_iters()
  File "/home/sumanta/Manhattan-LSTM/PyTorch/run_iterations.py", line 58, in train_iters
    loss, _ = self.model.train(input_variables, similarity_scores, self.criterion, model_optimizer)
  File "/home/sumanta/Manhattan-LSTM/PyTorch/train_network.py", line 32, in train
    output_scores = self.manhattan_lstm((sequences_1, sequences_2), hidden).view(-1)
  File "/home/sumanta/.local/lib/python3.6/site-packages/torch/nn/modules/module.py", line 532, in __call__
    result = self.forward(*input, **kwargs)
  File "/home/sumanta/Manhattan-LSTM/PyTorch/manhattan_lstm.py", line 42, in forward
    outputs_1, hidden_1 = self.lstm_1(embedded_1, hidden)
  File "/home/sumanta/.local/lib/python3.6/site-packages/torch/nn/modules/module.py", line 532, in __call__
    result = self.forward(*input, **kwargs)
  File "/home/sumanta/.local/lib/python3.6/site-packages/torch/nn/modules/rnn.py", line 559, in forward
    self.dropout, self.training, self.bidirectional, self.batch_first)
TypeError: lstm() received an invalid combination of arguments - got (Tensor, Tensor, list, bool, int, float, bool, bool, bool), but expected one of:
 * (Tensor data, Tensor batch_sizes, tuple of Tensors hx, tuple of Tensors params, bool has_biases, int num_layers, float dropout, bool train, bool bidirectional)
      didn't match because some of the arguments have invalid types: (Tensor, Tensor, list, bool, int, float, bool, bool, bool)
 * (Tensor input, tuple of Tensors hx, tuple of Tensors params, bool has_biases, int num_layers, float dropout, bool train, bool bidirectional, bool batch_first)
      didn't match because some of the arguments have invalid types: (Tensor, Tensor, list, bool, int, float, bool, bool, bool)

The root cause was erroneous hidden initialization.